### PR TITLE
[codex] feat: honor DF_SYMBOLIC binding

### DIFF
--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -89,6 +89,7 @@ pub(crate) struct ParsedDynamic {
     pub(crate) runpath_off: Option<NonZeroUsize>,
     pub(crate) dt_debug_idx: Option<usize>,
     pub(crate) bind_now: bool,
+    pub(crate) symbolic: bool,
     pub(crate) flags: usize,
     pub(crate) flags_1: usize,
     pub(crate) is_rela: Option<bool>,
@@ -115,6 +116,7 @@ impl ParsedDynamic {
             ElfDynamicTag::HASH => self.elf_hash_off = Some(value),
             ElfDynamicTag::GNU_HASH => self.gnu_hash_off = Some(value),
             ElfDynamicTag::BIND_NOW => self.bind_now = true,
+            ElfDynamicTag::SYMBOLIC => self.symbolic = true,
             ElfDynamicTag::SONAME => self.soname_off = NonZeroUsize::new(value),
             ElfDynamicTag::SYMTAB => self.symtab_off = value,
             ElfDynamicTag::STRTAB => self.strtab_off = value,
@@ -338,6 +340,7 @@ where
             bind_now: parsed.bind_now
                 || parsed.flags & DF_BIND_NOW as usize != 0
                 || parsed.flags_1 & DF_1_NOW as usize != 0,
+            symbolic: parsed.symbolic || parsed.flags & DF_SYMBOLIC as usize != 0,
             static_tls: parsed.flags & DF_STATIC_TLS as usize != 0,
             got_plt: parsed
                 .got_off
@@ -430,6 +433,8 @@ pub(crate) struct ElfDynamic<Arch: RelocationArch = NativeArch> {
     pub strtab_size: Option<NonZeroUsize>,
     /// Whether to bind symbols immediately.
     pub bind_now: bool,
+    /// Whether relocations in this object prefer definitions from itself.
+    pub symbolic: bool,
     /// Whether the object uses static thread-local storage.
     pub static_tls: bool,
     /// Global Offset Table address.
@@ -471,6 +476,7 @@ impl<Arch: RelocationArch> Debug for ElfDynamic<Arch> {
             .field("symtab", &format_args!("0x{:x}", self.symtab.get()))
             .field("strtab", &format_args!("0x{:x}", self.strtab.get()))
             .field("bind_now", &self.bind_now)
+            .field("symbolic", &self.symbolic)
             .field("static_tls", &self.static_tls)
             .field("got_plt", &self.got_plt)
             .field("needed_libs_count", &self.needed_libs.len())
@@ -494,6 +500,7 @@ impl<Arch: RelocationArch> Debug for ElfDynamic<Arch> {
 mod tests {
     use super::{ElfDyn, ElfDynamicTag, parse_dynamic_entries};
     use core::num::NonZeroUsize;
+    use elf::abi::DF_SYMBOLIC;
 
     #[test]
     fn owned_dyn_round_trips_and_mutates() {
@@ -517,5 +524,17 @@ mod tests {
 
         assert_eq!(parsed.soname_off, NonZeroUsize::new(0x24));
         assert!(parsed.bind_now);
+    }
+
+    #[test]
+    fn parses_symbolic_dynamic_flags() {
+        let parsed = parse_dynamic_entries([
+            (ElfDynamicTag::SYMBOLIC, 0),
+            (ElfDynamicTag::FLAGS, DF_SYMBOLIC as usize),
+            (ElfDynamicTag::NULL, 0),
+        ]);
+
+        assert!(parsed.symbolic);
+        assert_eq!(parsed.flags & DF_SYMBOLIC as usize, DF_SYMBOLIC as usize);
     }
 }

--- a/src/image/core/handle.rs
+++ b/src/image/core/handle.rs
@@ -179,6 +179,15 @@ impl<D: 'static, Arch: RelocationArch, R: RegionAccess, Tls: TlsResolver + 'stat
             .and_then(|info| info.soname)
     }
 
+    /// Returns whether dynamic relocations in this image prefer definitions from itself.
+    #[inline]
+    pub(crate) fn symbolic(&self) -> bool {
+        self.inner
+            .dynamic_info
+            .as_ref()
+            .is_some_and(|info| info.symbolic)
+    }
+
     /// Returns the mapped segments owned by this image.
     #[inline]
     pub fn segments(&self) -> &ElfSegments<R> {
@@ -279,6 +288,7 @@ impl<D: 'static, Arch: RelocationArch, R: RegionAccess, Tls: TlsResolver> ElfCor
                     eh_frame_hdr,
                     phdrs: ElfPhdrs::Vec(phdrs),
                     soname,
+                    symbolic: dynamic.symbolic,
                     #[cfg(feature = "lazy-binding")]
                     lazy: crate::image::LazyBindingInfo::new(dynamic.pltrel, lazy_symtab),
                     _tls: PhantomData,
@@ -331,6 +341,34 @@ where
     #[inline]
     fn tls(&self) -> ModuleTls {
         ElfCore::tls(self)
+    }
+}
+
+impl<D, Arch, R, Tls> Module<Arch, Tls> for CoreInner<D, Arch, R, Tls>
+where
+    D: 'static,
+    Arch: RelocationArch,
+    R: RegionAccess,
+    Tls: TlsResolver + 'static,
+{
+    #[inline]
+    fn name(&self) -> &str {
+        CoreInner::name(self)
+    }
+
+    #[inline]
+    fn exports(&self) -> &dyn SymbolExports<Arch::Layout> {
+        &*self.exports
+    }
+
+    #[inline]
+    fn memory(&self) -> &dyn ImageMemory {
+        &self.segments
+    }
+
+    #[inline]
+    fn tls(&self) -> ModuleTls {
+        ModuleTls::new(self.tls.mod_id(), self.tls.tp_offset())
     }
 }
 

--- a/src/image/core/loaded.rs
+++ b/src/image/core/loaded.rs
@@ -186,7 +186,7 @@ impl<D: 'static, Arch: RelocationArch, R: RegionAccess, Tls: TlsResolver + 'stat
         if sym.symbol_type() == ElfSymbolType::TLS {
             self.core.tls_addr(sym.st_value())
         } else {
-            Some(SymDef::<D, Arch, Tls>::new(Some(sym), self).addr())
+            Some(SymDef::<Arch, Tls>::new(Some(sym), self).addr())
         }
     }
 

--- a/src/image/elf/dynamic.rs
+++ b/src/image/elf/dynamic.rs
@@ -130,6 +130,7 @@ pub(crate) struct DynamicInfo<Arch: RelocationArch = NativeArch, Tls: TlsResolve
     pub(crate) eh_frame_hdr: Option<NonNull<u8>>,
     pub(crate) phdrs: ElfPhdrs<Arch::Layout>,
     pub(crate) soname: Option<&'static str>,
+    pub(crate) symbolic: bool,
     #[cfg(feature = "lazy-binding")]
     pub(crate) lazy: LazyBindingInfo<Arch, Tls>,
     pub(crate) _tls: PhantomData<fn() -> Tls>,
@@ -564,6 +565,7 @@ impl<D: 'static, Arch: RelocationArch, R: RegionAccess, Tls: TlsResolver>
                         eh_frame_hdr,
                         phdrs,
                         soname,
+                        symbolic: dynamic.symbolic,
                         #[cfg(feature = "lazy-binding")]
                         lazy: LazyBindingInfo::new(dynamic.pltrel.clone(), lazy_symtab),
                         _tls: PhantomData,

--- a/src/object/link.rs
+++ b/src/object/link.rs
@@ -198,7 +198,7 @@ where
 
                 let addr = if symbol.is_undef() {
                     let resolved = if let Some(symdef) =
-                        find_symdef_impl(&self.core, scope, symbol, &syminfo)
+                        find_symdef_impl(&self.core, scope, symbol, &syminfo, self.core.symbolic())
                     {
                         Some(symdef.resolve_addr(executor)?)
                     } else {

--- a/src/relocation/helper.rs
+++ b/src/relocation/helper.rs
@@ -13,7 +13,6 @@ use crate::{
     segment::ElfSegments,
     tls::{TLS_GET_ADDR_SYMBOL, TlsDescArgs, TlsResolver},
 };
-use core::marker::PhantomData;
 
 /// Internal context for managing relocation state and handlers.
 pub(crate) struct RelocHelper<
@@ -102,7 +101,13 @@ where
         let (dynsym, syminfo) = self.symbols.symbol_idx(rel.r_symbol());
         let resolved = if let Some(addr) = self.find_runtime_symbol(&syminfo) {
             Some(addr)
-        } else if let Some(symdef) = find_symdef_impl(self.core, &self.scope, dynsym, &syminfo) {
+        } else if let Some(symdef) = find_symdef_impl(
+            self.core,
+            &self.scope,
+            dynsym,
+            &syminfo,
+            self.core.symbolic(),
+        ) {
             Some(symdef.resolve_addr(self.executor)?)
         } else {
             None
@@ -130,9 +135,15 @@ where
     }
 
     #[inline]
-    pub(crate) fn find_symdef(&mut self, r_sym: usize) -> Option<SymDef<'_, D, Arch, Tls>> {
+    pub(crate) fn find_symdef(&mut self, r_sym: usize) -> Option<SymDef<'_, Arch, Tls>> {
         let (dynsym, syminfo) = self.symbols.symbol_idx(r_sym);
-        find_symdef_impl(self.core, &self.scope, dynsym, &syminfo)
+        find_symdef_impl(
+            self.core,
+            &self.scope,
+            dynsym,
+            &syminfo,
+            self.core.symbolic(),
+        )
     }
 }
 
@@ -140,25 +151,18 @@ where
 ///
 /// Contains the symbol information and the module where it was found.
 /// Used to compute the final address of a symbol.
-pub struct SymDef<'lib, D: 'static, Arch: RelocationArch, Tls: TlsResolver = ()> {
+pub struct SymDef<'lib, Arch: RelocationArch, Tls: TlsResolver = ()> {
     pub(crate) sym: Option<&'lib ElfSymbol<Arch::Layout>>,
     pub(crate) source: &'lib dyn Module<Arch, Tls>,
-    _marker: PhantomData<fn() -> D>,
 }
 
-impl<'lib, D: 'static, Arch: RelocationArch, Tls: TlsResolver + 'static>
-    SymDef<'lib, D, Arch, Tls>
-{
+impl<'lib, Arch: RelocationArch, Tls: TlsResolver + 'static> SymDef<'lib, Arch, Tls> {
     #[inline]
     pub(crate) fn new(
         sym: Option<&'lib ElfSymbol<Arch::Layout>>,
         source: &'lib dyn Module<Arch, Tls>,
     ) -> Self {
-        Self {
-            sym,
-            source,
-            _marker: PhantomData,
-        }
+        Self { sym, source }
     }
 
     /// Computes the symbol address (base + st_value).
@@ -259,61 +263,62 @@ where
     }
 }
 
-fn find_weak<'lib, D, Arch: RelocationArch, R: RegionAccess, Tls: TlsResolver + 'static>(
-    lib: &'lib ElfCore<D, Arch, R, Tls>,
-    dynsym: &'lib ElfSymbol<Arch::Layout>,
-) -> Option<SymDef<'lib, D, Arch, Tls>>
+fn weak_undef<'lib, Arch, Tls, Source>(
+    source: &'lib Source,
+    sym: &'lib ElfSymbol<Arch::Layout>,
+) -> Option<SymDef<'lib, Arch, Tls>>
 where
-    D: 'static,
+    Arch: RelocationArch,
+    Tls: TlsResolver + 'static,
+    Source: Module<Arch, Tls>,
 {
-    // 弱符号 + WEAK 用 0 填充rela offset
-    if dynsym.is_weak() && dynsym.is_undef() {
-        assert!(dynsym.st_value() == 0);
-        Some(SymDef::new(None, lib))
-    } else if dynsym.st_value() != 0 {
-        Some(SymDef::new(Some(dynsym), lib))
+    if sym.is_weak() && sym.is_undef() {
+        debug_assert_eq!(sym.st_value(), 0);
+        Some(SymDef::new(None, source))
     } else {
         None
     }
 }
 
-pub(crate) fn find_symdef_impl<
-    'lib,
-    D,
-    Arch: RelocationArch,
-    R: RegionAccess,
-    Tls: TlsResolver + 'static,
->(
-    core: &'lib ElfCore<D, Arch, R, Tls>,
+pub(crate) fn find_symdef_impl<'lib, Arch: RelocationArch, Tls: TlsResolver + 'static, Source>(
+    source: &'lib Source,
     scope: &'lib ModuleScope<Arch, Tls>,
     sym: &'lib ElfSymbol<Arch::Layout>,
     syminfo: &SymbolInfo,
-) -> Option<SymDef<'lib, D, Arch, Tls>>
+    symbolic: bool,
+) -> Option<SymDef<'lib, Arch, Tls>>
 where
-    D: 'static,
+    Source: Module<Arch, Tls>,
 {
     if unlikely(sym.is_local()) {
-        Some(SymDef::new(Some(sym), core))
-    } else {
-        let mut precompute = syminfo.precompute();
-        scope
-            .iter()
-            .find_map(|source| {
-                source
-                    .exports()
-                    .lookup(syminfo, &mut precompute)
-                    .map(|sym| {
-                        logging::trace!(
-                            "binding file [{}] to [{}]: symbol [{}]",
-                            core.name(),
-                            source.name(),
-                            syminfo.name()
-                        );
-                        SymDef::new(Some(sym), &**source)
-                    })
-            })
-            .or_else(|| find_weak(core, sym))
+        return Some(SymDef::new(Some(sym), source));
     }
+
+    let self_def = || (!sym.is_undef()).then(|| SymDef::new(Some(sym), source));
+    let scope_def = || {
+        let mut precompute = syminfo.precompute();
+        scope.iter().find_map(|scope_source| {
+            scope_source
+                .exports()
+                .lookup(syminfo, &mut precompute)
+                .map(|sym| {
+                    logging::trace!(
+                        "binding file [{}] to [{}]: symbol [{}]",
+                        source.name(),
+                        scope_source.name(),
+                        syminfo.name()
+                    );
+                    SymDef::new(Some(sym), &**scope_source)
+                })
+        })
+    };
+
+    if symbolic {
+        self_def().or_else(scope_def)
+    } else {
+        scope_def().or_else(self_def)
+    }
+    .or_else(|| weak_undef(source, sym))
 }
 
 #[inline]

--- a/src/relocation/lazy.rs
+++ b/src/relocation/lazy.rs
@@ -1,16 +1,15 @@
 #[cfg(feature = "lazy-binding")]
 mod enabled {
+    use super::super::helper::find_symdef_impl;
     use crate::image::{
         CoreInner, LazyBindingRuntime, ModuleScope, RawDylib, RawDynamic, RawElf, RawExec,
     };
     use crate::{
         RelocationError, Result,
         arch::prepare_lazy_bind,
-        elf::{ElfLayout, ElfRelEntry, ElfRelType, ElfWord, SymbolInfo},
+        elf::{ElfLayout, ElfRelEntry, ElfRelType, ElfWord},
         memory::{ImageMemory, RegionAccess, VmAddr, VmOffset},
-        relocation::{
-            BindingMode, ObjectRelocationArch, RelocationArch, SupportLazy, SymDef, unlikely,
-        },
+        relocation::{BindingMode, ObjectRelocationArch, RelocationArch, SupportLazy, unlikely},
         runtime::NativeCodeExecutor,
         sync::Arc,
         tls::{TLS_GET_ADDR_SYMBOL, TlsResolver},
@@ -35,32 +34,6 @@ mod enabled {
     impl<D: 'static, Arch: ObjectRelocationArch, R: RegionAccess, Tls: TlsResolver> SupportLazy
         for RawElf<D, Arch, R, Tls>
     {
-    }
-
-    fn lookup_addr<D, Arch, R, Tls>(
-        dylib: &CoreInner<D, Arch, R, Tls>,
-        scope: &ModuleScope<Arch, Tls>,
-        syminfo: &SymbolInfo<'_>,
-    ) -> Result<Option<VmAddr>>
-    where
-        D: 'static,
-        Arch: RelocationArch,
-        R: RegionAccess,
-        Tls: TlsResolver,
-    {
-        if Tls::OVERRIDE_TLS_GET_ADDR && syminfo.name() == TLS_GET_ADDR_SYMBOL {
-            return Ok(dylib.tls.tls_get_addr());
-        }
-
-        let mut precompute = syminfo.precompute();
-        for source in scope.iter() {
-            if let Some(sym) = source.exports().lookup(syminfo, &mut precompute) {
-                return SymDef::<D, Arch, Tls>::new(Some(sym), &**source)
-                    .resolve_addr(&NativeCodeExecutor)
-                    .map(Some);
-            }
-        }
-        Ok(None)
     }
 
     pub(crate) enum ResolvedBinding {
@@ -281,14 +254,20 @@ mod enabled {
             invalid_symbol_index(dylib.path.as_str(), r_sym, sym_count);
         }
 
-        let (_, syminfo) = symtab.symbol_idx(r_sym);
+        let (sym, syminfo) = symtab.symbol_idx(r_sym);
 
         let Some(scope) = dynamic_info.lazy.scope.get() else {
             invalid_state(dylib.path.as_str(), "missing lazy lookup")
         };
-        let symbol = lookup_addr::<D, Arch, R, Tls>(dylib, scope, &syminfo)
-            .unwrap_or_else(|_| invalid_state(dylib.path.as_str(), "lazy IFUNC resolution failed"))
-            .unwrap_or_else(|| unresolved_symbol(dylib.path.as_str(), syminfo.name()));
+        let symbol = if Tls::OVERRIDE_TLS_GET_ADDR && syminfo.name() == TLS_GET_ADDR_SYMBOL {
+            Ok(dylib.tls.tls_get_addr())
+        } else {
+            find_symdef_impl(dylib, scope, sym, &syminfo, dynamic_info.symbolic)
+                .map(|symdef| symdef.resolve_addr(&NativeCodeExecutor))
+                .transpose()
+        }
+        .unwrap_or_else(|_| invalid_state(dylib.path.as_str(), "lazy IFUNC resolution failed"))
+        .unwrap_or_else(|| unresolved_symbol(dylib.path.as_str(), syminfo.name()));
 
         unsafe {
             if ImageMemory::write_value(

--- a/src/relocation/traits.rs
+++ b/src/relocation/traits.rs
@@ -360,9 +360,9 @@ impl<'a, D: 'static, Arch: RelocationArch, R: RegionAccess, Tls: TlsResolver, H>
 
     /// Find symbol definition in the current scope
     #[inline]
-    pub fn find_symdef(&self, r_sym: usize) -> Option<SymDef<'a, D, Arch, Tls>> {
+    pub fn find_symdef(&self, r_sym: usize) -> Option<SymDef<'a, Arch, Tls>> {
         let (sym, syminfo) = self.symbol(r_sym);
-        find_symdef_impl(self.lib, self.scope, sym, &syminfo)
+        find_symdef_impl(self.lib, self.scope, sym, &syminfo, self.lib.symbolic())
     }
 }
 

--- a/tests/lazy_binding.rs
+++ b/tests/lazy_binding.rs
@@ -69,6 +69,19 @@ fn write_scope_func_consumer(config: ElfWriterConfig) -> ElfWriteOutput {
 }
 
 #[cfg(feature = "lazy-binding")]
+fn write_defining_scope_func_consumer(config: ElfWriterConfig) -> ElfWriteOutput {
+    let arch = Arch::current();
+    write_test_dylib_with_config(
+        config,
+        &[RelocEntry::jump_slot(SCOPED_FUNC_NAME, arch)],
+        &[SymbolDesc::global_func(
+            SCOPED_FUNC_NAME,
+            &return_42_stub(arch),
+        )],
+    )
+}
+
+#[cfg(feature = "lazy-binding")]
 fn scope_symbol_address(image: &LoadedCore<()>, symbol_name: &str) -> u64 {
     unsafe {
         image
@@ -192,6 +205,33 @@ fn default_lazy_binding_retains_scope_used_only_by_lazy_jump_slot() {
         jump_slot_word(&relocated, &consumer_output),
         scoped_func_addr
     );
+}
+
+#[cfg(feature = "lazy-binding")]
+#[test]
+fn df_symbolic_lazy_jump_slot_prefers_current_definition() {
+    let mut loader = Loader::new();
+    let provider_output = write_scope_provider();
+    let provider = load_relocated_dylib(&mut loader, "libscope_provider.so", &provider_output);
+    let consumer_output =
+        write_defining_scope_func_consumer(ElfWriterConfig::default().with_symbolic(true));
+
+    let relocated = loader
+        .load_dylib(ElfBinary::new("scope_consumer.so", &consumer_output.data))
+        .expect("failed to load scope consumer")
+        .relocator()
+        .scope(std::slice::from_ref(&provider))
+        .relocate()
+        .expect("failed to relocate scope consumer");
+
+    let self_func_addr = scope_symbol_address(&relocated, SCOPED_FUNC_NAME);
+    assert_ne!(
+        jump_slot_word(&relocated, &consumer_output),
+        self_func_addr,
+        "default lazy binding should leave the jump slot unresolved before the first call"
+    );
+    assert_eq!(call_scope_helper(&relocated), 42);
+    assert_eq!(jump_slot_word(&relocated, &consumer_output), self_func_addr);
 }
 
 #[cfg(feature = "lazy-binding")]

--- a/tests/symbol_resolution.rs
+++ b/tests/symbol_resolution.rs
@@ -9,11 +9,11 @@ use elf_loader::{
 };
 
 const REL_GOT: u32 = <NativeArch as RelocationArch>::GOT.raw();
-use gen_elf::{Arch, ElfWriteOutput, RelocEntry, SymbolDesc};
+use gen_elf::{Arch, ElfWriteOutput, ElfWriterConfig, RelocEntry, SymbolDesc};
 use support::{
     dylib_relocation_checks::{relocation_for_symbol, slot_word},
     host_symbols::{EXTERNAL_VAR_NAME, TestHostSymbols},
-    test_dylib::{load_relocated_dylib, write_test_dylib},
+    test_dylib::{load_relocated_dylib, write_test_dylib, write_test_dylib_with_config},
 };
 
 const SHARED_VAR_NAME: &str = "shared_var";
@@ -27,6 +27,19 @@ fn write_got_consumer(symbol_name: &str) -> ElfWriteOutput {
     write_test_dylib(
         &[RelocEntry::glob_dat(symbol_name, arch)],
         &[SymbolDesc::undefined_object(symbol_name)],
+    )
+}
+
+fn write_defining_got_consumer(
+    config: ElfWriterConfig,
+    symbol_name: &str,
+    data: &[u8],
+) -> ElfWriteOutput {
+    let arch = Arch::current();
+    write_test_dylib_with_config(
+        config,
+        &[RelocEntry::glob_dat(symbol_name, arch)],
+        &[SymbolDesc::global_object(symbol_name, data)],
     )
 }
 
@@ -154,4 +167,56 @@ fn extend_scope_keeps_existing_precedence() {
     assert_eq!(scope.len(), 2, "all scope entries should be retained");
     assert_eq!(scope[0].name(), first.name());
     assert_eq!(scope[1].name(), second.name());
+}
+
+#[test]
+fn scope_definition_interposes_current_definition_by_default() {
+    let mut loader = Loader::new();
+    let helper_output = write_helper_dylib(SHARED_VAR_NAME, &[0x11, 0x22, 0x33, 0x44]);
+    let helper = load_relocated_dylib(&mut loader, "libscope.so", &helper_output);
+    let consumer_output = write_defining_got_consumer(
+        ElfWriterConfig::default().with_bind_now(true),
+        SHARED_VAR_NAME,
+        &[0x55, 0x66, 0x77, 0x88],
+    );
+
+    let relocated = loader
+        .load_dylib(ElfBinary::new("consumer.so", &consumer_output.data))
+        .expect("failed to load consumer")
+        .relocator()
+        .scope(std::slice::from_ref(&helper))
+        .relocate()
+        .expect("failed to relocate consumer");
+
+    assert_eq!(
+        got_slot_word(&relocated, &consumer_output, SHARED_VAR_NAME),
+        symbol_address(&helper, SHARED_VAR_NAME)
+    );
+}
+
+#[test]
+fn df_symbolic_prefers_current_definition_over_scope() {
+    let mut loader = Loader::new();
+    let helper_output = write_helper_dylib(SHARED_VAR_NAME, &[0x11, 0x22, 0x33, 0x44]);
+    let helper = load_relocated_dylib(&mut loader, "libscope.so", &helper_output);
+    let consumer_output = write_defining_got_consumer(
+        ElfWriterConfig::default()
+            .with_bind_now(true)
+            .with_symbolic(true),
+        SHARED_VAR_NAME,
+        &[0x55, 0x66, 0x77, 0x88],
+    );
+
+    let relocated = loader
+        .load_dylib(ElfBinary::new("consumer.so", &consumer_output.data))
+        .expect("failed to load consumer")
+        .relocator()
+        .scope(std::slice::from_ref(&helper))
+        .relocate()
+        .expect("failed to relocate consumer");
+
+    assert_eq!(
+        got_slot_word(&relocated, &consumer_output, SHARED_VAR_NAME),
+        symbol_address(&relocated, SHARED_VAR_NAME)
+    );
 }

--- a/tools/gen-elf/src/dylib/dynamic.rs
+++ b/tools/gen-elf/src/dylib/dynamic.rs
@@ -28,6 +28,7 @@ impl DynamicMetadata {
         sections: &[Section],
         allocator: &mut SectionAllocator,
         bind_now: bool,
+        symbolic: bool,
         soname_offset: Option<u32>,
         needed_offsets: &[u32],
     ) -> Self {
@@ -44,8 +45,15 @@ impl DynamicMetadata {
         for offset in needed_offsets {
             instance.insert_entry(DT_NEEDED, *offset as u64);
         }
+        let mut flags = 0;
         if bind_now {
-            instance.update_entry(DT_FLAGS, DF_BIND_NOW as u64);
+            flags |= DF_BIND_NOW as u64;
+        }
+        if symbolic {
+            flags |= DF_SYMBOLIC as u64;
+        }
+        if flags != 0 {
+            instance.update_entry(DT_FLAGS, flags);
         }
         instance
     }

--- a/tools/gen-elf/src/dylib/mod.rs
+++ b/tools/gen-elf/src/dylib/mod.rs
@@ -61,6 +61,8 @@ pub struct ElfWriterConfig {
     pub ifunc_resolver_val: Option<u64>,
     /// Whether the generated ELF should request eager binding by default.
     pub bind_now: bool,
+    /// Whether the generated ELF should prefer its own definitions during relocation.
+    pub symbolic: bool,
     /// Whether to emit one retained relocation section for the data section.
     pub emit_retained_relocations: bool,
     /// DT_SONAME entry to emit into the dynamic section.
@@ -76,6 +78,7 @@ impl Default for ElfWriterConfig {
             page_size: 0x1000,
             ifunc_resolver_val: None,
             bind_now: false,
+            symbolic: false,
             emit_retained_relocations: false,
             soname: None,
             needed: Vec::new(),
@@ -105,6 +108,12 @@ impl ElfWriterConfig {
     /// Set whether the generated ELF should request eager binding by default.
     pub fn with_bind_now(mut self, bind_now: bool) -> Self {
         self.bind_now = bind_now;
+        self
+    }
+
+    /// Set whether the generated ELF should prefer its own definitions during relocation.
+    pub fn with_symbolic(mut self, symbolic: bool) -> Self {
+        self.symbolic = symbolic;
         self
     }
 
@@ -303,6 +312,7 @@ impl DylibWriter {
             &sections,
             &mut allocator,
             self.config.bind_now,
+            self.config.symbolic,
             symtab.soname_offset(),
             symtab.needed_offsets(),
         );


### PR DESCRIPTION
## Summary

- Parse `DT_SYMBOLIC` / `DF_SYMBOLIC` from dynamic metadata and preserve symbolic binding state on loaded dynamic cores.
- Use the symbolic flag to prefer the defining object during eager and lazy symbol resolution.
- Extend generated DSO metadata and regression tests for default interposition versus DF_SYMBOLIC self-first lookup.

Closes #61

## Validation

- `cargo test -q`
- `cargo test --features lazy-binding -q`
- `cargo test --target=x86_64-unknown-linux-gnu --no-default-features --features use-syscall,object -q`
- `cargo check -p windows-elf-loader -q`