### PR TITLE
feat: made base address accessible from LoadedExec

### DIFF
--- a/src/image/elf/exec.rs
+++ b/src/image/elf/exec.rs
@@ -434,6 +434,14 @@ impl<D: Send + Sync + 'static, Arch: RelocationArch, R: RegionAccess, Tls: TlsRe
             LoadedExecInner::Static(static_image) => static_image.tls(),
         }
     }
+
+    /// Returns the runtime base address.
+    pub fn base(&self) -> VmAddr {
+        match &self.inner {
+            LoadedExecInner::Dynamic(module) => module.base(),
+            LoadedExecInner::Static(static_image) => static_image.base(),
+        }
+    }
 }
 
 impl<Tls, D: Send + Sync + 'static, Arch: RelocationArch, R: RegionAccess>


### PR DESCRIPTION
trivial getter for the base address of a loaded executable